### PR TITLE
ci: add format/lint jobs and align PR checks across all repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,31 +39,9 @@ jobs:
     - name: Check code formatting (Spotless)
       run: mvn spotless:check -q
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        java-version: '21'
-        distribution: 'temurin'
-
-    - name: Cache Maven dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-
-    - name: Run linter (Spotless)
-      run: mvn spotless:check -q
-
   test:
     runs-on: ubuntu-latest
-    needs: [format, lint]
+    needs: [format]
     environment: dev
 
     strategy:
@@ -154,7 +132,7 @@ jobs:
         path: target/site/jacoco/
 
   build:
-    needs: [format, lint]
+    needs: [format]
     runs-on: ubuntu-latest
 
     steps:
@@ -248,7 +226,7 @@ jobs:
         docker inspect otel-example-quarkus:pr-${{ github.event.pull_request.number }}
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.24.0
       with:
         image-ref: otel-example-quarkus:pr-${{ github.event.pull_request.number }}
         format: 'sarif'
@@ -258,7 +236,7 @@ jobs:
 
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v4
-      if: always()
+      if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         sarif_file: 'trivy-results.sarif'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read
@@ -13,8 +17,53 @@ permissions:
   statuses: write
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
+    - name: Check code formatting (Spotless)
+      run: mvn spotless:check -q
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
+    - name: Run linter (Spotless)
+      run: mvn spotless:check -q
+
   test:
     runs-on: ubuntu-latest
+    needs: [format, lint]
     environment: dev
 
     strategy:
@@ -105,7 +154,7 @@ jobs:
         path: target/site/jacoco/
 
   build:
-    needs: test
+    needs: [format, lint]
     runs-on: ubuntu-latest
 
     steps:
@@ -166,6 +215,52 @@ jobs:
 
     - name: Update deployment status
       run: echo "Docker image built and pushed successfully"
+
+  docker-build:
+    runs-on: ubuntu-latest
+    needs: [test, build]
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image for PR validation
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: false
+        tags: otel-example-quarkus:pr-${{ github.event.pull_request.number }}
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Verify Docker image was built
+      run: |
+        echo "Listing Docker images:"
+        docker images
+        echo "Checking if our image exists:"
+        docker inspect otel-example-quarkus:pr-${{ github.event.pull_request.number }}
+
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: otel-example-quarkus:pr-${{ github.event.pull_request.number }}
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+      env:
+        TRIVY_SKIP_VERSION_CHECK: true
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v4
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'
 
   integration-test:
     needs: docker

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help test fmt fmt-check verify clean
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+test: ## Run tests (H2 in-memory DB via Quarkus test profile)
+	mvn test
+
+fmt: ## Auto-format code with Spotless (google-java-format AOSP)
+	mvn spotless:apply
+
+fmt-check: ## Check formatting without making changes (use in CI)
+	mvn spotless:check
+
+lint: fmt-check ## Alias for fmt-check
+
+verify: ## Run format check + full test suite
+	mvn spotless:check
+	mvn test
+
+clean: ## Remove build output
+	mvn clean

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test fmt fmt-check verify clean
+.PHONY: help test fmt fmt-check lint verify clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
@@ -14,9 +14,7 @@ fmt-check: ## Check formatting without making changes (use in CI)
 
 lint: fmt-check ## Alias for fmt-check
 
-verify: ## Run format check + full test suite
-	mvn spotless:check
-	mvn test
+verify: fmt-check test ## Run format check + full test suite
 
 clean: ## Remove build output
 	mvn clean

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <jacoco.version>0.8.14</jacoco.version>
+        <spotless.version>2.44.5</spotless.version>
+        <google-java-format.version>1.27.0</google-java-format.version>
 
         <!-- SonarCloud Configuration -->
         <sonar.projectKey>devops-thiago_otel-example-quarkus</sonar.projectKey>
@@ -282,16 +284,16 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>${spotless.version}</version>
                 <configuration>
                     <java>
                         <googleJavaFormat>
-                            <version>1.19.2</version>
+                            <version>${google-java-format.version}</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
-                        <removeUnusedImports />
-                        <trimTrailingWhitespace />
-                        <endWithNewline />
+                        <removeUnusedImports/>
+                        <trimTrailingWhitespace/>
+                        <endWithNewline/>
                     </java>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## What
Align CI pipeline structure across all 6 OTel repos.

## Changes
- Add concurrency block to cancel stale runs on new pushes
- Add format and lint jobs using each repo native tooling
- Gate test and build on format+lint passing
- Add PR-only docker-build job with Trivy vulnerability scan
- .NET: split docker-build (PR gate) from docker-publish (main-only push)