### PR TITLE
fix(security): force OpenTelemetry >= 1.62.0 to fix CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
 
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.version>3.36.3</quarkus.version>
+        <!-- Security override: force OpenTelemetry >= 1.62.0 to fix CVE-2026-45292
+             (Quarkus 3.36.3 BOM pins opentelemetry-api to 1.60.1). -->
+        <opentelemetry.version>1.62.0</opentelemetry.version>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
         <jacoco.version>0.8.15</jacoco.version>
@@ -55,6 +58,16 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Imported BEFORE the Quarkus BOM so its OpenTelemetry versions win
+                 (Maven managed-dependency resolution is first-declared-wins).
+                 Forces opentelemetry-api/sdk >= 1.62.0 to fix CVE-2026-45292. -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus.platform</groupId>
                 <artifactId>quarkus-bom</artifactId>


### PR DESCRIPTION
## Summary

A trivy scan flagged several HIGH/MEDIUM CVEs in this Quarkus project. Most are governed by the Quarkus platform BOM, which `main` already bumped to **3.36.3** (Dependabot). That bump clears:

- `io.quarkus:quarkus-vertx-http` **CVE-2026-39852** (authorization bypass) → resolved at 3.36.3
- `io.vertx:vertx-core` **CVE-2026-6860** (DoS) → resolves to **4.5.28** (>= 4.5.27)
- `io.netty:netty-handler` / `io.netty:netty-resolver-dns` findings → resolve to **4.1.135.Final** (latest 4.1.x)

However, the Quarkus 3.36.3 BOM still pins `io.opentelemetry:opentelemetry-api` to **1.60.1**, leaving **CVE-2026-45292** (OpenTelemetry DoS / unbounded memory, fixed in 1.62.0) open.

## Change

Import `io.opentelemetry:opentelemetry-bom` **1.62.0** in `dependencyManagement` **before** the Quarkus BOM. Maven managed-dependency resolution is first-declared-wins, so all OpenTelemetry artifacts now resolve to >= 1.62.0. A `${opentelemetry.version}` property is added for clarity/maintainability. This is the only change; no application code touched.

## Verification

Resolved versions after the change:

| Artifact | Version | Fix floor |
|---|---|---|
| `io.opentelemetry:opentelemetry-api` | **1.62.0** | >= 1.62.0 |
| `io.vertx:vertx-core` | **4.5.28** | >= 4.5.27 |
| `io.quarkus:quarkus-vertx-http` | **3.36.3** | >= 3.35.1.1 |
| `io.netty:netty-handler` / `netty-resolver-dns` | **4.1.135.Final** | latest 4.1.x |

- `mvn -B clean verify`: **BUILD SUCCESS**, 115 tests pass, JaCoCo coverage gate met, Spotless clean
- `trivy fs --scanners vuln --severity HIGH,CRITICAL,MEDIUM`: **0 vulnerabilities**
- `osv-scanner` over a CycloneDX SBOM (222 packages, full transitive graph): **No issues found**

🤖 Generated with [Claude Code](https://claude.com/claude-code)